### PR TITLE
 obs-scripting: Allow passing python methods as callbacks

### DIFF
--- a/deps/obs-scripting/obs-scripting-python-frontend.c
+++ b/deps/obs-scripting/obs-scripting-python-frontend.c
@@ -319,7 +319,7 @@ static PyObject *remove_save_callback(PyObject *self, PyObject *args)
 
 	if (!parse_args(args, "O", &py_cb))
 		return python_none();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return python_none();
 
 	struct python_obs_callback *cb =
@@ -343,7 +343,7 @@ static PyObject *add_save_callback(PyObject *self, PyObject *args)
 
 	if (!parse_args(args, "O", &py_cb))
 		return python_none();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return python_none();
 
 	struct python_obs_callback *cb = add_python_obs_callback(script, py_cb);
@@ -389,7 +389,7 @@ static PyObject *remove_event_callback(PyObject *self, PyObject *args)
 
 	if (!parse_args(args, "O", &py_cb))
 		return python_none();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return python_none();
 
 	struct python_obs_callback *cb =
@@ -413,7 +413,7 @@ static PyObject *add_event_callback(PyObject *self, PyObject *args)
 
 	if (!parse_args(args, "O", &py_cb))
 		return python_none();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return python_none();
 
 	struct python_obs_callback *cb = add_python_obs_callback(script, py_cb);

--- a/deps/obs-scripting/obs-scripting-python-import.c
+++ b/deps/obs-scripting/obs-scripting-python-import.c
@@ -181,7 +181,8 @@ bool import_python(const char *python_path, python_version_t *python_version)
 	IMPORT_FUNC(PyCapsule_New);
 	IMPORT_FUNC(PyCapsule_GetPointer);
 	IMPORT_FUNC(PyArg_ParseTuple);
-	IMPORT_FUNC(PyFunction_Type);
+    IMPORT_FUNC(PyFunction_Type);
+    IMPORT_FUNC(PyMethod_Type);
 	IMPORT_FUNC(PyObject_SetAttr);
 	IMPORT_FUNC(_PyObject_New);
 	IMPORT_FUNC(PyCapsule_Import);

--- a/deps/obs-scripting/obs-scripting-python-import.c
+++ b/deps/obs-scripting/obs-scripting-python-import.c
@@ -181,8 +181,8 @@ bool import_python(const char *python_path, python_version_t *python_version)
 	IMPORT_FUNC(PyCapsule_New);
 	IMPORT_FUNC(PyCapsule_GetPointer);
 	IMPORT_FUNC(PyArg_ParseTuple);
-    IMPORT_FUNC(PyFunction_Type);
-    IMPORT_FUNC(PyMethod_Type);
+	IMPORT_FUNC(PyFunction_Type);
+	IMPORT_FUNC(PyMethod_Type);
 	IMPORT_FUNC(PyObject_SetAttr);
 	IMPORT_FUNC(_PyObject_New);
 	IMPORT_FUNC(PyCapsule_Import);

--- a/deps/obs-scripting/obs-scripting-python-import.h
+++ b/deps/obs-scripting/obs-scripting-python-import.h
@@ -129,6 +129,7 @@ PY_EXTERN void *(*Import_PyCapsule_GetPointer)(PyObject *capsule,
 					       const char *name);
 PY_EXTERN int (*Import_PyArg_ParseTuple)(PyObject *, const char *, ...);
 PY_EXTERN PyTypeObject(*Import_PyFunction_Type);
+PY_EXTERN PyTypeObject(*Import_PyMethod_Type);
 PY_EXTERN int (*Import_PyObject_SetAttr)(PyObject *, PyObject *, PyObject *);
 PY_EXTERN PyObject *(*Import__PyObject_New)(PyTypeObject *);
 PY_EXTERN void *(*Import_PyCapsule_Import)(const char *name, int no_block);
@@ -217,6 +218,7 @@ extern bool import_python(const char *python_path,
 #define PyCapsule_GetPointer Import_PyCapsule_GetPointer
 #define PyArg_ParseTuple Import_PyArg_ParseTuple
 #define PyFunction_Type (*Import_PyFunction_Type)
+#define PyMethod_Type (*Import_PyMethod_Type)
 #define PyObject_SetAttr Import_PyObject_SetAttr
 #define _PyObject_New Import__PyObject_New
 #define PyCapsule_Import Import_PyCapsule_Import

--- a/deps/obs-scripting/obs-scripting-python.c
+++ b/deps/obs-scripting/obs-scripting-python.c
@@ -507,7 +507,7 @@ static PyObject *obs_python_remove_tick_callback(PyObject *self, PyObject *args)
 
 	if (!parse_args(args, "O", &py_cb))
 		return python_none();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return python_none();
 
 	struct python_obs_callback *cb =
@@ -532,7 +532,7 @@ static PyObject *obs_python_add_tick_callback(PyObject *self, PyObject *args)
 
 	if (!parse_args(args, "O", &py_cb))
 		return python_none();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return python_none();
 
 	struct python_obs_callback *cb = add_python_obs_callback(script, py_cb);
@@ -590,7 +590,7 @@ static PyObject *obs_python_signal_handler_disconnect(PyObject *self,
 
 	if (!py_to_libobs(signal_handler_t, py_sh, &handler))
 		return python_none();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return python_none();
 
 	struct python_obs_callback *cb =
@@ -635,7 +635,7 @@ static PyObject *obs_python_signal_handler_connect(PyObject *self,
 		return python_none();
 	if (!py_to_libobs(signal_handler_t, py_sh, &handler))
 		return python_none();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return python_none();
 
 	struct python_obs_callback *cb = add_python_obs_callback(script, py_cb);
@@ -695,7 +695,7 @@ static PyObject *obs_python_signal_handler_disconnect_global(PyObject *self,
 
 	if (!py_to_libobs(signal_handler_t, py_sh, &handler))
 		return python_none();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return python_none();
 
 	struct python_obs_callback *cb =
@@ -737,7 +737,7 @@ static PyObject *obs_python_signal_handler_connect_global(PyObject *self,
 
 	if (!py_to_libobs(signal_handler_t, py_sh, &handler))
 		return python_none();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return python_none();
 
 	struct python_obs_callback *cb = add_python_obs_callback(script, py_cb);
@@ -828,7 +828,7 @@ static PyObject *hotkey_unregister(PyObject *self, PyObject *args)
 
 	if (!parse_args(args, "O", &py_cb))
 		return python_none();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return python_none();
 
 	struct python_obs_callback *cb =
@@ -850,7 +850,7 @@ static PyObject *hotkey_register_frontend(PyObject *self, PyObject *args)
 
 	if (!parse_args(args, "ssO", &name, &desc, &py_cb))
 		return py_invalid_hotkey_id();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return py_invalid_hotkey_id();
 
 	struct python_obs_callback *cb = add_python_obs_callback(script, py_cb);
@@ -915,7 +915,7 @@ static PyObject *properties_add_button(PyObject *self, PyObject *args)
 		return python_none();
 	if (!py_to_libobs(obs_properties_t, py_props, &props))
 		return python_none();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return python_none();
 
 	struct python_obs_callback *cb = add_python_obs_callback(script, py_cb);
@@ -979,7 +979,7 @@ static PyObject *property_set_modified_callback(PyObject *self, PyObject *args)
 		return python_none();
 	if (!py_to_libobs(obs_property_t, py_p, &p))
 		return python_none();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return python_none();
 
 	struct python_obs_callback *cb = add_python_obs_callback(script, py_cb);


### PR DESCRIPTION
When adding an object as callback, obs-scripting-python requires the object to be of function type, which excludes bound method objects, although they are perfectly valid as a callback object.

This changes the type check in functions that add script callbacks so that bound methods pass it.